### PR TITLE
Fixes of a few issues in the search functions

### DIFF
--- a/src/sources/video/hanime.ts
+++ b/src/sources/video/hanime.ts
@@ -94,7 +94,7 @@ export const HAnime = class {
 
 			let allResults: HAnimeSearchResult[] = [];
 			try {
-				const rawResults = JSON.parse(data.hits) as HAnimeRawSearchResult[];
+				const rawResults = JSON.parse(JSON.stringify(data.hits)) as HAnimeRawSearchResult[];
 				allResults = rawResults.map((result) => this.mapToSearchResult(result));
 			} catch (error) {
 				console.error("Failed to parse search results:", error);

--- a/src/sources/video/hentai-haven.ts
+++ b/src/sources/video/hentai-haven.ts
@@ -24,7 +24,7 @@ export const HentaiHaven = class {
 	 * @param {string} [options.baseUrl] - Custom base URL for the HentaiHaven website.
 	 */
 	constructor(options: HentaiHavenOptions) {
-		this.BASE_URL = options.baseUrl || HENTAI_HAVEN_URL;
+		this.BASE_URL = options?.baseUrl || HENTAI_HAVEN_URL;
 	}
 
 	/**


### PR DESCRIPTION
Using `.search` for `HentaiHaven` and `HAnime` will throw an error and make them unusable.

**HentaiHaven:**
Error:
```js
Cannot read properties of undefined (reading 'baseUrl')
at new HentaiHaven (node_modules/@mohtasimalam/hentai.js/src/sources/video/hentai-haven.ts:27:27)
```

Fixed by: [1fec8c5](https://github.com/shimizudev/hentaijs/commit/1fec8c592f9ea331e0fe411797ded177ade7102c)


**HAnime:**
Error:
```js
Failed to parse search results: Unexpected token 'o', "[object Obj"... is not valid JSON
at JSON.parse (<anonymous>)
at HAnime.search (node_modules/@mohtasimalam/hentai.js/src/sources/video/hanime.ts:97:29)
```

Fixed by: [6638b42](https://github.com/shimizudev/hentaijs/commit/6638b42f9ca12e6128f129173074c279271df147)